### PR TITLE
Update Helper.js

### DIFF
--- a/src/Helper.js
+++ b/src/Helper.js
@@ -19,7 +19,11 @@ const get = (obj, path, defaultValue) => {
 				obj = undefined;
 			}
 		} else {
-			obj = obj[comp];
+			if (isNaN(comp)) {
+				obj = obj[comp];
+			} else {
+				obj = obj[('undefined' === typeof obj[comp] ? Number(comp) : comp)];
+			}
 		}
 	}
 


### PR DESCRIPTION
Add casting to number when the stringed key references an undefined value in object so it can retrieve numbered indices (like those of an array).